### PR TITLE
Fix never ending digest cycles

### DIFF
--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -452,8 +452,8 @@
                         numLoaded++;
                     });
                     
-                    if (shouldDigest) $scope.$apply()
-                }, 200);
+                    if (shouldDigest) $scope.$apply();
+                }, 200, 0, false);
                 $element.on('$destroy', function() {
                     $interval.cancel(poller);
                 });

--- a/dist/angular-pdfjs-viewer.js
+++ b/dist/angular-pdfjs-viewer.js
@@ -412,6 +412,7 @@
                 }
                 
                 var poller = $interval(function () {
+                    var shouldDigest = false;
                     if (!window.PDFViewerApplication) {
                         return;
                     }
@@ -439,6 +440,7 @@
                         }
                         
                         if (pageNum in loaded) return;
+                        shouldDigest = true;
 
                         if (!initialised) onPdfInit();
                         
@@ -449,8 +451,9 @@
                         loaded[pageNum] = true;
                         numLoaded++;
                     });
+                    
+                    if (shouldDigest) $scope.$apply()
                 }, 200);
-
                 $element.on('$destroy', function() {
                     $interval.cancel(poller);
                 });

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -109,6 +109,7 @@
                 }
                 
                 var poller = $interval(function () {
+                    var shouldDigest = false;
                     if (!window.PDFViewerApplication) {
                         return;
                     }
@@ -136,6 +137,7 @@
                         }
                         
                         if (pageNum in loaded) return;
+                        shouldDigest = true;
 
                         if (!initialised) onPdfInit();
                         
@@ -146,6 +148,8 @@
                         loaded[pageNum] = true;
                         numLoaded++;
                     });
+                    
+                    if (shouldDigest) $scope.$apply()
                 }, 200);
 
                 $element.on('$destroy', function() {

--- a/src/angular-pdfjs-viewer.js
+++ b/src/angular-pdfjs-viewer.js
@@ -148,9 +148,9 @@
                         loaded[pageNum] = true;
                         numLoaded++;
                     });
-                    
-                    if (shouldDigest) $scope.$apply()
-                }, 200);
+
+                    if (shouldDigest) $scope.$apply();
+                }, 200, 0, false);
 
                 $element.on('$destroy', function() {
                     $interval.cancel(poller);


### PR DESCRIPTION
$interval is causing a digest loop on root scope every time it works.Angularjs using a 200 millisecond $interval that causes big angular apps to work very hard.This fix applies the digest cycle on scope only if something actually happened during the $interval logic.


